### PR TITLE
Add support request form view

### DIFF
--- a/src/web/app/components/support-request-edit-form/support-request-edit-form-model.ts
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form-model.ts
@@ -1,0 +1,37 @@
+import { SupportRequestCategory, SupportRequestStatus } from '../../../types/api-output';
+
+/**
+ * The mode of operation for Support request edit form.
+ */
+export enum SupportRequestFormMode {
+    /**
+     * Adding a new supportRequest (User).
+     */
+    USER_ADD,
+
+    /**
+     * Editing the existing supportRequest as a User.
+     */
+    USER_EDIT,
+
+    /**
+     * Editing the existing supportRequest as an Admin.
+     */
+    ADMIN_EDIT,
+}
+
+/**
+ * The form model of supportRequest form.
+ */
+export interface SupportRequestFormModel {
+    id: string,
+    email: string,
+    title: string,
+    description: string,
+    status: SupportRequestStatus,
+    category: SupportRequestCategory,
+    response: string,
+    hasNewChanges: boolean,
+    createdAt: number,
+    modifiedAt: number,
+};

--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.component.html
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.component.html
@@ -1,0 +1,45 @@
+<div class="user-submission-section">
+  <div class="one-line-field form-group">
+    <label class="form-label">Email:</label>
+    <input type="text" [(ngModel)]="formModel.email" class="form-control" [disabled]="formMode === SupportRequestFormMode.ADMIN_EDIT">
+  </div>
+
+  <div class="one-line-field form-group">
+    <label class="form-label">Title:</label>
+    <input type="text" [(ngModel)]="formModel.title" class="form-control" [disabled]="formMode === SupportRequestFormMode.ADMIN_EDIT">
+  </div>
+
+  <div class="form-group">
+    <label class="form-label">Category:</label>
+    <select class="category-dropdown" [(ngModel)]="this.formModel.category" [disabled]="formMode === SupportRequestFormMode.ADMIN_EDIT">
+      <option *ngFor="let c of categories" [value]="c"> 
+        {{ enumToOption(c) }} 
+      </option>
+    </select>
+  </div>
+  <br/>
+
+  <div class="form-group">
+    <label class="form-label">Description:</label>
+    <textarea [(ngModel)]="formModel.description" class="form-control" style="height: 100px;" [disabled]="formMode === SupportRequestFormMode.ADMIN_EDIT"></textarea>
+  </div>
+</div>
+
+<div class="admin-response-section form-group" *ngIf="formMode !== SupportRequestFormMode.USER_ADD">
+    <div style="display: flex; justify-content: space-between; margin: 10px; align-items: flex-end;">
+      <label class="form-label">Response:</label>
+      <select class="status-dropdown" [(ngModel)]="this.formModel.status">
+        <option class="status-option" [value]="statuses[0]"> {{ enumToOption(statuses[0]) }} </option>
+        <option [disabled]="formMode !== SupportRequestFormMode.ADMIN_EDIT" class="status-option" [value]="statuses[1]"> {{ enumToOption(statuses[1]) }} </option>
+        <option [disabled]="formMode !== SupportRequestFormMode.USER_EDIT" class="status-option" [value]="statuses[2]"> {{ enumToOption(statuses[2]) }} </option>
+        <option [disabled]="formMode !== SupportRequestFormMode.ADMIN_EDIT" class="status-option" [value]="statuses[3]"> {{ enumToOption(statuses[3]) }} </option>
+      </select>
+    </div>
+    
+    <textarea [(ngModel)]="formModel.response" class="form-control" style="height: 100px;" [disabled]="formMode === SupportRequestFormMode.USER_EDIT"></textarea>
+</div>
+
+<div  style="display: flex; justify-content: center;">
+  <button *ngIf="formMode === SupportRequestFormMode.USER_ADD" (click)="onCreate()" class="btn btn-success">SUBMIT</button>
+  <button *ngIf="formMode !== SupportRequestFormMode.USER_ADD" (click)="onUpdate()" class="btn btn-success">EDIT</button>
+</div>

--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.component.html
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.component.html
@@ -23,6 +23,12 @@
     <label class="form-label">Description:</label>
     <textarea [(ngModel)]="formModel.description" class="form-control" style="height: 100px;" [disabled]="formMode === SupportRequestFormMode.ADMIN_EDIT"></textarea>
   </div>
+
+  <div class="form-group" *ngIf="formMode !== SupportRequestFormMode.USER_ADD">
+    <small style="color: grey; font-size: small;">Created on: {{ formModel.createdAt | date:'EEE, dd MMM, yyyy, h:mma' }} </small>
+    <br>
+    <small style="color: grey; font-size: small;" *ngIf="formModel.createdAt !== formModel.modifiedAt">Last Modified: {{ formModel.modifiedAt | date:'EEE, dd MMM, yyyy, h:mma' }}</small>
+  </div>
 </div>
 
 <div class="admin-response-section form-group" *ngIf="formMode !== SupportRequestFormMode.USER_ADD">

--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.component.scss
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.component.scss
@@ -1,0 +1,45 @@
+.user-submission-section {
+    border: 2px solid orange;
+    padding: 10px;
+    border-radius: 5px;
+    margin: 10px 0px;
+}
+
+.admin-response-section {
+    background-color: rgb(229, 229, 229);
+    padding: 10px;
+    border-radius: 5px;
+    margin: 10px 0px;
+}
+
+.form-label {
+    font-weight: bolder;
+    color: grey;
+    min-width: 100px;
+    width: auto;
+    margin: 0px 5px 0px 0px;
+}
+
+.one-line-field {
+    display: flex;
+    align-items: center;
+}
+
+.form-group {
+    margin: 10px 0px;
+}
+
+.status-dropdown {
+    background-color: white;
+    border: 1px solid lightgrey;
+    padding: 5px;
+    border-radius: 5px;
+}
+
+.category-dropdown {
+    background-color: white;
+    border: 1px solid lightgrey;
+    padding: 5px;
+    margin: 0px;
+    border-radius: 5px;
+}

--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
@@ -96,7 +96,7 @@ export class SupportRequestEditFormComponent implements OnInit {
                 response: "Please provide more information!",
                 hasNewChanges: false,
                 createdAt: 1,
-                modifiedAt: 1,
+                modifiedAt: new Date().getTime(),
             }
         }
     }

--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
@@ -1,0 +1,119 @@
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { StatusMessageService } from "src/web/services/status-message.service";
+import { SupportRequestCategory, SupportRequestStatus } from "src/web/types/api-output";
+import { ErrorMessageOutput } from "../../error-message-output";
+import { SupportRequestFormModel, SupportRequestFormMode } from "./support-request-edit-form-model";
+
+/**
+ * The support request edit form component.
+ */
+@Component({
+selector: 'tm-support-request-edit-form',
+templateUrl: './support-request-edit-form.component.html',
+styleUrls: ['./support-request-edit-form.component.scss'],
+})
+export class SupportRequestEditFormComponent implements OnInit {
+    // enum
+    SupportRequestFormMode: typeof SupportRequestFormMode = SupportRequestFormMode;
+
+    @Input()
+    supportRequestId: string = "";
+
+    @Input()
+    email: string = "";
+
+    @Input()
+    formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
+
+    formModel: SupportRequestFormModel = {
+        id: "",
+        email: "",
+        title: "",
+        description: "",
+        status: SupportRequestStatus.SUBMITTED,
+        category: SupportRequestCategory.OTHERS,
+        response: "",
+        hasNewChanges: true,
+        createdAt: 1,
+        modifiedAt: 1,
+    }
+
+    @Output()
+    onCreateSupportRequestEvent: EventEmitter<SupportRequestFormModel> = new EventEmitter();
+
+    @Output()
+    onUpdateSupportRequestEvent: EventEmitter<SupportRequestFormModel> = new EventEmitter();
+    
+
+    public categories: String[] = Object.values(SupportRequestCategory);
+    public statuses: String[] = Object.values(SupportRequestStatus);
+
+    constructor (private route: ActivatedRoute,
+                private statusMessageService: StatusMessageService) {
+    }
+
+    ngOnInit(): void {
+        this.formModel.email = this.email;
+        let srId = "";
+
+        if (this.formMode === SupportRequestFormMode.ADMIN_EDIT) {
+            srId = this.supportRequestId;
+            
+        } else if (this.formMode === SupportRequestFormMode.USER_EDIT) {
+            this.route.queryParams.subscribe({
+                next: (queryParams: any) => {
+                    if (queryParams != null) {
+                        srId = queryParams.supportRequestId;
+                    }
+                },
+                error: (err: ErrorMessageOutput) => {
+                    this.statusMessageService.showErrorToast(err.error.message);
+                }
+            })
+        }
+
+        if (srId !== "") {
+            // this.supportRequestService.getSupportRequestById(this.supportRequestId).subscribe({
+            //      next: (sr SupportRequest) => {
+            //             this.model.id = sr.id 
+            //             // continue with other fields
+            //      },
+            //      error: (err: ErrorMessageOutput) => {
+            //          this.isLoading = false;
+            //          // showErrorToast
+            //          // set formModel to default fields 
+            //      }
+            // })
+            
+            this.formModel = { // Mock data – TO REPLACE
+                id: "123 123 Mock data",
+                email: "abc@gmail.com",
+                title: "Mock data title for Support Request",
+                description: "<description>",
+                status: SupportRequestStatus.PENDING,
+                category: SupportRequestCategory.BUG_REPORT,
+                response: "Please provide more information!",
+                hasNewChanges: false,
+                createdAt: 1,
+                modifiedAt: 1,
+            }
+        }
+    }
+
+    public enumToOption(str: String) {
+        return str.split("_").map(word => word.charAt(0) + word.slice(1).toLowerCase()).join(" ");
+    }
+
+    public onCreate(): void {
+        let now = new Date().getTime();
+        this.formModel.createdAt = now;
+        this.formModel.modifiedAt = now;
+        this.onCreateSupportRequestEvent.emit(this.formModel);
+    }
+
+    public onUpdate(): void {
+        this.formModel.modifiedAt = new Date().getTime();
+        this.onUpdateSupportRequestEvent.emit(this.formModel);
+    }
+}

--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.module.ts
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.module.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { SupportRequestEditFormComponent } from "./support-request-edit-form.component";
+
+
+/**
+ * Module for all support request edit UI.
+ */
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  declarations: [
+    SupportRequestEditFormComponent,
+  ],
+  exports: [
+    SupportRequestEditFormComponent,
+  ],
+})
+export class SupportRequestEditFormModule { }

--- a/src/web/app/components/support-requests-table/support-requests-table.component.html
+++ b/src/web/app/components/support-requests-table/support-requests-table.component.html
@@ -180,7 +180,7 @@
                   editingMode: true
                 }"
               > -->
-              <button type="button" class="btn btn-light btn-sm">Edit</button>
+              <button type="button" class="btn btn-light btn-sm" (click)="navToSupportRequest(supportRequestsTableRowModel.supportRequest.id)">Edit</button>
               <!-- </a> -->
             </div>
           </td>

--- a/src/web/app/components/support-requests-table/support-requests-table.component.ts
+++ b/src/web/app/components/support-requests-table/support-requests-table.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { NavigationService } from "src/web/services/navigation.service";
 import { SortBy, SortOrder } from "../../../types/sort-properties";
 import {
   SupportRequestsTableColumn,
@@ -40,12 +41,24 @@ export class SupportRequestsTableComponent {
   sortSupportRequestsTableRowModelsEvent: EventEmitter<SortBy> =
     new EventEmitter();
 
-  constructor() {}
+  constructor(private navigationService: NavigationService) {}
 
   /**
    * Sorts the list of support request row.
    */
   sortSupportRequestsTableRowModels(by: SortBy): void {
     this.sortSupportRequestsTableRowModelsEvent.emit(by);
+  }
+
+
+  public navToSupportRequest(srId: string) {
+    let url = `/web/admin/requests/edit-request`;
+    let params: Record<string, string> = {
+      supportRequestId: srId
+    }
+    this.navigationService.navigateByURL(url, params).then(v => {
+      console.log("Navigated to ", url, v);
+    });
+    
   }
 }

--- a/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.html
+++ b/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.html
@@ -1,0 +1,18 @@
+<div *ngIf="supportRequestId === ''">
+    <p class="align-center alert alert-danger">Support Request ID is invalid. Please check that the URL is correct!</p>
+</div>
+
+<div *ngIf="supportRequestId !== ''">
+    <ng-template #loadingSpinner>
+        <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
+    </ng-template>
+    <div *ngIf="!isLoading; else loadingSpinner">    
+        <h1 class="color-orange">Edit Support Request Response</h1>
+        <tm-support-request-edit-form
+            [supportRequestId]="this.supportRequestId" 
+            [formMode]="this.formMode"
+            (onUpdateSupportRequestEvent)="updateSupportRequest($event)"
+            >
+        </tm-support-request-edit-form>
+    </div>
+</div>

--- a/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.scss
+++ b/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.scss
@@ -1,0 +1,4 @@
+tm-ajax-loading {
+    display: flex; 
+    justify-content: center;
+}

--- a/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminEditSupportRequestPageComponent } from './admin-edit-support-request-page.component';
+
+describe('AdminEditSupportRequestPageComponent', () => {
+  let component: AdminEditSupportRequestPageComponent;
+  let fixture: ComponentFixture<AdminEditSupportRequestPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AdminEditSupportRequestPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminEditSupportRequestPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.ts
+++ b/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { StatusMessageService } from "src/web/services/status-message.service";
+import { SupportRequestFormMode, SupportRequestFormModel } from "../../components/support-request-edit-form/support-request-edit-form-model";
+// import { SupportRequestService } from "src/web/services/support-request.service"; 
+import { ErrorMessageOutput } from "../../error-message-output";
+
+@Component({
+    selector: 'tm-admin-edit-support-request-page',
+    templateUrl: './admin-edit-support-request-page.component.html',
+    styleUrls: ['./admin-edit-support-request-page.component.scss']
+})
+export class AdminEditSupportRequestPageComponent implements OnInit {
+    
+    constructor(private route: ActivatedRoute,
+                private statusMessageService: StatusMessageService) {
+    }
+
+    supportRequestId: String = "";
+    formMode: SupportRequestFormMode = SupportRequestFormMode.ADMIN_EDIT;
+    isLoading: boolean = false;
+
+    ngOnInit() {
+        this.isLoading = true;
+        this.route.queryParams.subscribe({
+            next: (queryParams: any) => {
+                this.isLoading = false;
+                if (queryParams != null) {
+                    this.supportRequestId = queryParams.supportRequestId || "";
+                } else {
+                    this.supportRequestId = "";
+                }
+            },
+            error: (err: ErrorMessageOutput) => {
+                this.isLoading = false;
+                this.supportRequestId = "";
+                this.statusMessageService.showErrorToast(err.error.message);
+            }
+        })
+    }
+
+    public updateSupportRequest(_formModel: SupportRequestFormModel) {
+        this.isLoading = true;
+        console.log("Updating DB...");
+        this.isLoading = false;
+    }
+}

--- a/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.module.ts
+++ b/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.module.ts
@@ -1,0 +1,43 @@
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
+import { AjaxPreloadModule } from '../../components/ajax-preload/ajax-preload.module';
+import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
+import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
+import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
+import { NgModule } from '@angular/core';
+import { AdminEditSupportRequestPageComponent } from './admin-edit-support-request-page.component';
+import { SupportRequestEditFormModule } from "../../components/support-request-edit-form/support-request-edit-form.module";
+import { FormsModule } from '@angular/forms';
+
+
+const routes: Routes = [
+  {
+    path: '',
+    component: AdminEditSupportRequestPageComponent,
+  },
+];
+
+/**
+ * Module for edit support request page (ADMIN_EDIT).
+ */
+@NgModule({
+  declarations: [
+    AdminEditSupportRequestPageComponent,
+  ],
+  exports: [
+    AdminEditSupportRequestPageComponent,
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    AjaxPreloadModule,
+    RouterModule.forChild(routes),
+    SupportRequestEditFormModule,
+    AjaxLoadingModule,
+    LoadingRetryModule,
+    ProgressBarModule,
+    LoadingSpinnerModule,
+  ],
+})
+export class AdminEditSupportRequestPageModule { }

--- a/src/web/app/pages-admin/admin-pages.module.ts
+++ b/src/web/app/pages-admin/admin-pages.module.ts
@@ -49,8 +49,19 @@ const routes: Routes = [
   },
   {
     path: 'requests',
-    loadChildren: () => import('./admin-support-requests-page/admin-support-requests-page.module')
-        .then((m: any) => m.AdminSupportRequestsPageModule),
+    children: [
+      {
+        path: '',
+        loadChildren: () => import('./admin-support-requests-page/admin-support-requests-page.module')
+            .then((m: any) => m.AdminSupportRequestsPageModule),
+      },
+      {
+        path: 'edit-request',
+        loadChildren: () => import('./admin-edit-support-request-page/admin-edit-support-request-page.module')
+            .then((m: any) => m.AdminEditSupportRequestPageModule),
+      }
+    ]
+    
   },
   {
     path: 'logs',

--- a/src/web/app/pages-instructor/instructor-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-page.component.ts
@@ -44,6 +44,10 @@ export class InstructorPageComponent implements OnInit {
       display: 'Notifications',
     },
     {
+      url: '/web/instructor/support-request',
+      display: 'Support Request',
+    },
+    {
       url: '/web/instructor/help',
       display: 'Help',
     },

--- a/src/web/app/pages-instructor/instructor-pages.module.ts
+++ b/src/web/app/pages-instructor/instructor-pages.module.ts
@@ -148,6 +148,11 @@ const routes: Routes = [
         .then((m: any) => m.InstructorNotificationsPageModule),
   },
   {
+    path: 'support-request',
+    loadChildren: () => import('./instructor-support-request-page/instructor-support-request-page.module')
+        .then((m: any) => m.InstructorSupportRequestPageModule),
+  },
+  {
     path: 'help',
     loadChildren: () => import('../pages-help/instructor-help-page/instructor-help-page.module')
         .then((m: any) => m.InstructorHelpPageModule),

--- a/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.html
+++ b/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.html
@@ -1,0 +1,13 @@
+<ng-template #loadingSpinner>
+    <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
+</ng-template>
+<div *ngIf="!isLoading; else loadingSpinner">    
+    <h1 class="color-orange">Request for Support</h1>
+    <p>Please fill in this form to submit a Support Request, including: Bug reports, New feature suggestions, Inquiries, etc.</p>
+    <tm-support-request-edit-form
+        [email]="this.email" 
+        [formMode]="this.formMode"
+        (onCreateSupportRequestEvent)="createNewSupportRequest($event)"
+        >
+    </tm-support-request-edit-form>
+</div>

--- a/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.html
+++ b/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.html
@@ -2,6 +2,13 @@
     <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
 </ng-template>
 <div *ngIf="!isLoading; else loadingSpinner">    
+    <div *ngIf="successMsg.length > 0" class="alert alert-success" style="display: flex; flex-direction: column; ">
+        <div *ngFor="let m of successMsg">
+            <p>{{ m }}</p>
+        </div>
+        
+        <button (click)="onDismissSuccessMessage()" class="btn btn-sm"><p>dismiss</p></button>
+    </div>
     <h1 class="color-orange">Request for Support</h1>
     <p>Please fill in this form to submit a Support Request, including: Bug reports, New feature suggestions, Inquiries, etc.</p>
     <tm-support-request-edit-form

--- a/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.scss
@@ -1,0 +1,4 @@
+tm-ajax-loading {
+    display: flex; 
+    justify-content: center;
+}

--- a/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InstructorSupportRequestPageComponent } from './instructor-support-request-page.component';
+
+describe('InstructorSupportRequestPageComponent', () => {
+  let component: InstructorSupportRequestPageComponent;
+  let fixture: ComponentFixture<InstructorSupportRequestPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ InstructorSupportRequestPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InstructorSupportRequestPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.ts
@@ -6,6 +6,7 @@ import { ErrorMessageOutput } from '../../error-message-output';
 import { SupportRequestFormMode, SupportRequestFormModel } from '../../components/support-request-edit-form/support-request-edit-form-model';
 import { StatusMessageService } from 'src/web/services/status-message.service';
 import { AuthService } from 'src/web/services/auth.service';
+import { LinkService } from 'src/web/services/link.service';
 
 @Component({
   selector: 'tm-instructor-support-request-page',
@@ -22,12 +23,17 @@ export class InstructorSupportRequestPageComponent implements OnInit {
   email = "";
   formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
 
+  successMsg: string[] = [];
+  private SUCCESSFUL_CREATE_MESSAGE: string[] = ["Successfully submitted a SupportRequest!", "Please save this link to view/make updates to your support request:"]; 
+
   constructor(private supportRequestService: SupportRequestService,
               private statusMessageService: StatusMessageService,
-              private authService: AuthService) { }
+              private authService: AuthService,
+              private linkService: LinkService) { }
 
   ngOnInit(): void {
     this.formMode = SupportRequestFormMode.USER_ADD;
+    this.successMsg = [];
 
     this.isLoading = true;
     this.email = "";
@@ -63,8 +69,10 @@ export class InstructorSupportRequestPageComponent implements OnInit {
 
     this.isLoading = true;
     this.supportRequestService.createSupportRequest(req).subscribe({
-      next: (_sr: SupportRequest) => {
-        this.statusMessageService.showSuccessToast("Successfully submitted a Support Request");
+      next: (sr: SupportRequest) => {
+        let sr_url = this.linkService.generateEditSupportRequestUrl(sr.id);
+        this.successMsg = this.SUCCESSFUL_CREATE_MESSAGE
+        this.successMsg.push(sr_url);
       },
       error: (err: ErrorMessageOutput) => {
         this.statusMessageService.showErrorToast(err.error.message);
@@ -73,5 +81,9 @@ export class InstructorSupportRequestPageComponent implements OnInit {
         this.isLoading = false;
       }
     });
+  }
+
+  onDismissSuccessMessage(): void {
+    this.successMsg = [];
   }
 }

--- a/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnInit } from '@angular/core';
+import { SupportRequestService } from 'src/web/services/support-request.service';
+import { AuthInfo, SupportRequest } from 'src/web/types/api-output';
+import { SupportRequestCreateRequest } from 'src/web/types/api-request';
+import { ErrorMessageOutput } from '../../error-message-output';
+import { SupportRequestFormMode, SupportRequestFormModel } from '../../components/support-request-edit-form/support-request-edit-form-model';
+import { StatusMessageService } from 'src/web/services/status-message.service';
+import { AuthService } from 'src/web/services/auth.service';
+
+@Component({
+  selector: 'tm-instructor-support-request-page',
+  templateUrl: './instructor-support-request-page.component.html',
+  styleUrls: ['./instructor-support-request-page.component.scss']
+})
+export class InstructorSupportRequestPageComponent implements OnInit {
+  // enum
+  SupportRequestFormMode: typeof SupportRequestFormMode = SupportRequestFormMode;
+
+  isLoading: boolean = false;
+  sr: SupportRequest | null = null;
+
+  email = "";
+  formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
+
+  constructor(private supportRequestService: SupportRequestService,
+              private statusMessageService: StatusMessageService,
+              private authService: AuthService) { }
+
+  ngOnInit(): void {
+    this.formMode = SupportRequestFormMode.USER_ADD;
+
+    this.isLoading = true;
+    this.email = "";
+    this.authService.getAuthUser().subscribe({
+      next: (res: AuthInfo) => {
+        if (res.user) {
+          console.log(res.user);
+          this.email = res.user?.id || "";
+        } 
+      },
+      error: () => {
+        // Fail silently
+      },
+      complete: () => {
+        this.isLoading = false;
+      }
+    });
+  }
+
+  public createNewSupportRequest(formModel: SupportRequestFormModel) {
+    let req: SupportRequestCreateRequest = {
+        id: formModel.id,
+        email: formModel.email,
+        title: formModel.title,
+        description: formModel.description,
+        createdAt: new Date().getTime(),
+        modifiedAt: new Date().getTime(),
+        status: formModel.status,
+        category: formModel.category,
+        response: formModel.response,
+        hasNewChanges: formModel.hasNewChanges   
+    };
+
+    this.isLoading = true;
+    this.supportRequestService.createSupportRequest(req).subscribe({
+      next: (_sr: SupportRequest) => {
+        this.statusMessageService.showSuccessToast("Successfully submitted a Support Request");
+      },
+      error: (err: ErrorMessageOutput) => {
+        this.statusMessageService.showErrorToast(err.error.message);
+      },
+      complete: () => {
+        this.isLoading = false;
+      }
+    });
+  }
+}

--- a/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-support-request-page/instructor-support-request-page.module.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
+import { AjaxPreloadModule } from '../../components/ajax-preload/ajax-preload.module';
+import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
+import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
+import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
+import { NgModule } from '@angular/core';
+import { InstructorSupportRequestPageComponent } from './instructor-support-request-page.component';
+import { SupportRequestEditFormModule } from '../../components/support-request-edit-form/support-request-edit-form.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: InstructorSupportRequestPageComponent,
+  },
+];
+
+/**
+ * Module for Instructor Support Request page.
+ */
+@NgModule({
+  declarations: [
+    InstructorSupportRequestPageComponent,
+  ],
+  exports: [
+    InstructorSupportRequestPageComponent,
+  ],
+  imports: [
+    CommonModule,
+    AjaxPreloadModule,
+    RouterModule.forChild(routes),
+    SupportRequestEditFormModule,
+    AjaxLoadingModule,
+    LoadingRetryModule,
+    ProgressBarModule,
+    LoadingSpinnerModule,
+  ],
+})
+export class InstructorSupportRequestPageModule { }

--- a/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.html
+++ b/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.html
@@ -1,0 +1,18 @@
+<div *ngIf="supportRequestId === ''">
+    <p class="align-center alert alert-danger">Support Request ID is invalid. Please check that the URL is correct!</p>
+</div>
+
+<div *ngIf="supportRequestId !== ''">
+    <ng-template #loadingSpinner>
+        <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
+    </ng-template>
+    <div *ngIf="!isLoading; else loadingSpinner">    
+        <h1 class="color-orange">Edit Support Request</h1>
+        <tm-support-request-edit-form
+            [supportRequestId]="this.supportRequestId" 
+            [formMode]="this.formMode"
+            (onUpdateSupportRequestEvent)="updateSupportRequest($event)"
+            >
+        </tm-support-request-edit-form>
+    </div>
+</div>

--- a/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.scss
+++ b/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.scss
@@ -1,0 +1,4 @@
+tm-ajax-loading {
+    display: flex; 
+    justify-content: center;
+}

--- a/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.spec.ts
+++ b/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditSupportRequestPageComponent } from './edit-support-request-page.component';
+
+describe('EditSupportRequestPageComponent', () => {
+  let component: EditSupportRequestPageComponent;
+  let fixture: ComponentFixture<EditSupportRequestPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EditSupportRequestPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditSupportRequestPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.ts
+++ b/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { StatusMessageService } from "src/web/services/status-message.service";
+import { SupportRequestFormMode, SupportRequestFormModel } from "../../components/support-request-edit-form/support-request-edit-form-model";
+// import { SupportRequestService } from "src/web/services/support-request.service"; 
+import { ErrorMessageOutput } from "../../error-message-output";
+
+@Component({
+    selector: 'tm-edit-support-request-page',
+    templateUrl: './edit-support-request-page.component.html',
+    styleUrls: ['./edit-support-request-page.component.scss']
+})
+export class EditSupportRequestPageComponent implements OnInit {
+    
+    constructor(private route: ActivatedRoute,
+                private statusMessageService: StatusMessageService) {
+    }
+
+    supportRequestId: String = "";
+    formMode: SupportRequestFormMode = SupportRequestFormMode.USER_EDIT;
+    isLoading: boolean = false;
+
+    ngOnInit() {
+        this.isLoading = true;
+        this.route.queryParams.subscribe({
+            next: (queryParams: any) => {
+                this.isLoading = false;
+                if (queryParams != null) {
+                    this.supportRequestId = queryParams.supportRequestId || "";
+                } else {
+                    this.supportRequestId = "";
+                }
+            },
+            error: (err: ErrorMessageOutput) => {
+                this.isLoading = false;
+                this.supportRequestId = "";
+                this.statusMessageService.showErrorToast(err.error.message);
+            }
+        })
+    }
+
+    public updateSupportRequest(_formModel: SupportRequestFormModel) {
+        this.isLoading = true;
+        console.log("Updating DB...");
+        this.isLoading = false;
+    }
+}

--- a/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.module.ts
+++ b/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.module.ts
@@ -1,0 +1,43 @@
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
+import { AjaxPreloadModule } from '../../components/ajax-preload/ajax-preload.module';
+import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
+import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
+import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
+import { NgModule } from '@angular/core';
+import { EditSupportRequestPageComponent } from './edit-support-request-page.component';
+import { SupportRequestEditFormModule } from "../../components/support-request-edit-form/support-request-edit-form.module";
+import { FormsModule } from '@angular/forms';
+
+
+const routes: Routes = [
+  {
+    path: '',
+    component: EditSupportRequestPageComponent,
+  },
+];
+
+/**
+ * Module for edit support request page (USER_EDIT).
+ */
+@NgModule({
+  declarations: [
+    EditSupportRequestPageComponent,
+  ],
+  exports: [
+    EditSupportRequestPageComponent,
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    AjaxPreloadModule,
+    RouterModule.forChild(routes),
+    SupportRequestEditFormModule,
+    AjaxLoadingModule,
+    LoadingRetryModule,
+    ProgressBarModule,
+    LoadingSpinnerModule,
+  ],
+})
+export class EditSupportRequestPageModule { }

--- a/src/web/app/pages-static/static-page.component.ts
+++ b/src/web/app/pages-static/static-page.component.ts
@@ -41,6 +41,10 @@ export class StaticPageComponent implements OnInit {
       display: 'Terms',
     },
     {
+      url: '/web/front/support-request',
+      display: 'Support Request',
+    },
+    {
       display: 'Help',
       children: [
         {

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -65,6 +65,10 @@ const routes: Routes = [
     loadChildren: () => import('./support-request-page/support-request-page.module').then((m: any) => m.SupportRequestPageModule),
   },
   {
+    path: 'edit-support-request',
+    loadChildren: () => import('./edit-support-request-page/edit-support-request-page.module').then((m: any) => m.EditSupportRequestPageModule),
+  },
+  {
     path: '',
     pathMatch: 'full',
     redirectTo: 'home',

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -61,6 +61,10 @@ const routes: Routes = [
     ],
   },
   {
+    path: 'support-request',
+    loadChildren: () => import('./support-request-page/support-request-page.module').then((m: any) => m.SupportRequestPageModule),
+  },
+  {
     path: '',
     pathMatch: 'full',
     redirectTo: 'home',

--- a/src/web/app/pages-static/support-request-page/support-request-page.component.html
+++ b/src/web/app/pages-static/support-request-page/support-request-page.component.html
@@ -1,0 +1,13 @@
+<ng-template #loadingSpinner>
+    <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
+</ng-template>
+<div *ngIf="!isLoading; else loadingSpinner">    
+    <h1 class="color-orange">Request for Support</h1>
+    <p>Please fill in this form to submit a Support Request, including: Bug reports, New feature suggestions, Inquiries, etc.</p>
+    <tm-support-request-edit-form
+        [email]="this.email" 
+        [formMode]="this.formMode"
+        (onCreateSupportRequestEvent)="createNewSupportRequest($event)"
+        >
+    </tm-support-request-edit-form>
+</div>

--- a/src/web/app/pages-static/support-request-page/support-request-page.component.html
+++ b/src/web/app/pages-static/support-request-page/support-request-page.component.html
@@ -2,6 +2,13 @@
     <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
 </ng-template>
 <div *ngIf="!isLoading; else loadingSpinner">    
+    <div *ngIf="successMsg.length > 0" class="alert alert-success" style="display: flex; flex-direction: column; ">
+        <div *ngFor="let m of successMsg">
+            <p>{{ m }}</p>
+        </div>
+        
+        <button (click)="onDismissSuccessMessage()" class="btn btn-sm"><p>dismiss</p></button>
+    </div>
     <h1 class="color-orange">Request for Support</h1>
     <p>Please fill in this form to submit a Support Request, including: Bug reports, New feature suggestions, Inquiries, etc.</p>
     <tm-support-request-edit-form

--- a/src/web/app/pages-static/support-request-page/support-request-page.component.scss
+++ b/src/web/app/pages-static/support-request-page/support-request-page.component.scss
@@ -1,0 +1,4 @@
+tm-ajax-loading {
+    display: flex; 
+    justify-content: center;
+}

--- a/src/web/app/pages-static/support-request-page/support-request-page.component.spec.ts
+++ b/src/web/app/pages-static/support-request-page/support-request-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SupportRequestPageComponent } from './support-request-page.component';
+
+describe('SupportRequestPageComponent', () => {
+  let component: SupportRequestPageComponent;
+  let fixture: ComponentFixture<SupportRequestPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SupportRequestPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SupportRequestPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-static/support-request-page/support-request-page.component.ts
+++ b/src/web/app/pages-static/support-request-page/support-request-page.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit } from '@angular/core';
+import { SupportRequestService } from 'src/web/services/support-request.service';
+import { SupportRequest } from 'src/web/types/api-output';
+import { SupportRequestCreateRequest } from 'src/web/types/api-request';
+import { ErrorMessageOutput } from '../../error-message-output';
+import { SupportRequestFormMode, SupportRequestFormModel } from '../../components/support-request-edit-form/support-request-edit-form-model';
+import { StatusMessageService } from 'src/web/services/status-message.service';
+
+@Component({
+  selector: 'tm-support-request-page',
+  templateUrl: './support-request-page.component.html',
+  styleUrls: ['./support-request-page.component.scss']
+})
+export class SupportRequestPageComponent implements OnInit {
+  // enum
+  SupportRequestFormMode: typeof SupportRequestFormMode = SupportRequestFormMode;
+
+  isLoading: boolean = false;
+  sr: SupportRequest | null = null;
+
+  email = "";
+  formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
+
+  constructor(private supportRequestService: SupportRequestService,
+              private statusMessageService: StatusMessageService) { }
+
+  ngOnInit(): void {
+    this.email = "";
+    this.formMode = SupportRequestFormMode.USER_ADD;
+  }
+
+  public createNewSupportRequest(formModel: SupportRequestFormModel) {
+    let req: SupportRequestCreateRequest = {
+        id: formModel.id,
+        email: formModel.email,
+        title: formModel.title,
+        description: formModel.description,
+        createdAt: new Date().getTime(),
+        modifiedAt: new Date().getTime(),
+        status: formModel.status,
+        category: formModel.category,
+        response: formModel.response,
+        hasNewChanges: formModel.hasNewChanges   
+    };
+
+    this.isLoading = true;
+    this.supportRequestService.createSupportRequest(req).subscribe({
+      next: (_sr: SupportRequest) => {
+        this.isLoading = false;
+        this.statusMessageService.showSuccessToast("Successfully submitted a SupportRequest");
+      },
+      error: (err: ErrorMessageOutput) => {
+        this.isLoading = false;
+        this.statusMessageService.showErrorToast(err.error.message);
+      }
+    });
+  }
+}

--- a/src/web/app/pages-static/support-request-page/support-request-page.component.ts
+++ b/src/web/app/pages-static/support-request-page/support-request-page.component.ts
@@ -5,6 +5,7 @@ import { SupportRequestCreateRequest } from 'src/web/types/api-request';
 import { ErrorMessageOutput } from '../../error-message-output';
 import { SupportRequestFormMode, SupportRequestFormModel } from '../../components/support-request-edit-form/support-request-edit-form-model';
 import { StatusMessageService } from 'src/web/services/status-message.service';
+import { LinkService } from 'src/web/services/link.service';
 
 @Component({
   selector: 'tm-support-request-page',
@@ -21,12 +22,17 @@ export class SupportRequestPageComponent implements OnInit {
   email = "";
   formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
 
+  successMsg: string[] = [];
+  private SUCCESSFUL_CREATE_MESSAGE: string[] = ["Successfully submitted a SupportRequest!", "Please save this link to view/make updates to your support request:"]; 
+
   constructor(private supportRequestService: SupportRequestService,
-              private statusMessageService: StatusMessageService) { }
+              private statusMessageService: StatusMessageService,
+              private linkService: LinkService) { }
 
   ngOnInit(): void {
     this.email = "";
     this.formMode = SupportRequestFormMode.USER_ADD;
+    this.successMsg = [];
   }
 
   public createNewSupportRequest(formModel: SupportRequestFormModel) {
@@ -45,14 +51,20 @@ export class SupportRequestPageComponent implements OnInit {
 
     this.isLoading = true;
     this.supportRequestService.createSupportRequest(req).subscribe({
-      next: (_sr: SupportRequest) => {
+      next: (sr: SupportRequest) => {
         this.isLoading = false;
-        this.statusMessageService.showSuccessToast("Successfully submitted a SupportRequest");
+        let sr_url = this.linkService.generateEditSupportRequestUrl(sr.id);
+        this.successMsg = this.SUCCESSFUL_CREATE_MESSAGE
+        this.successMsg.push(sr_url);
       },
       error: (err: ErrorMessageOutput) => {
         this.isLoading = false;
         this.statusMessageService.showErrorToast(err.error.message);
       }
     });
+  }
+
+  onDismissSuccessMessage(): void {
+    this.successMsg = [];
   }
 }

--- a/src/web/app/pages-static/support-request-page/support-request-page.module.ts
+++ b/src/web/app/pages-static/support-request-page/support-request-page.module.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
+import { AjaxPreloadModule } from '../../components/ajax-preload/ajax-preload.module';
+import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
+import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
+import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
+import { NgModule } from '@angular/core';
+import { SupportRequestPageComponent } from './support-request-page.component';
+import { SupportRequestEditFormModule } from '../../components/support-request-edit-form/support-request-edit-form.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SupportRequestPageComponent,
+  },
+];
+
+/**
+ * Module for Public Support Request page.
+ */
+@NgModule({
+  declarations: [
+    SupportRequestPageComponent,
+  ],
+  exports: [
+    SupportRequestPageComponent,
+  ],
+  imports: [
+    CommonModule,
+    AjaxPreloadModule,
+    RouterModule.forChild(routes),
+    SupportRequestEditFormModule,
+    AjaxLoadingModule,
+    LoadingRetryModule,
+    ProgressBarModule,
+    LoadingSpinnerModule,
+  ],
+})
+export class SupportRequestPageModule { }

--- a/src/web/app/pages-student/student-page.component.ts
+++ b/src/web/app/pages-student/student-page.component.ts
@@ -32,6 +32,10 @@ export class StudentPageComponent implements OnInit {
       display: 'Notifications',
     },
     {
+      url: '/web/student/support-request',
+      display: 'Support Request',
+    },
+    {
       url: '/web/student/help',
       display: 'Help',
     },

--- a/src/web/app/pages-student/student-pages.module.ts
+++ b/src/web/app/pages-student/student-pages.module.ts
@@ -52,6 +52,11 @@ const routes: Routes = [
         .then((m: any) => m.StudentNotificationsPageModule),
   },
   {
+    path: 'support-request',
+    loadChildren: () => import('./student-support-request-page/student-support-request-page.module')
+        .then((m: any) => m.StudentSupportRequestPageModule),
+  },
+  {
     path: 'help',
     loadChildren: () => import('../pages-help/student-help-page/student-help-page.module')
         .then((m: any) => m.StudentHelpPageModule),

--- a/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.html
+++ b/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.html
@@ -1,0 +1,13 @@
+<ng-template #loadingSpinner>
+    <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
+</ng-template>
+<div *ngIf="!isLoading; else loadingSpinner">    
+    <h1 class="color-orange">Request for Support</h1>
+    <p>Please fill in this form to submit a Support Request, including: Bug reports, New feature suggestions, Inquiries, etc.</p>
+    <tm-support-request-edit-form
+        [email]="this.email" 
+        [formMode]="this.formMode"
+        (onCreateSupportRequestEvent)="createNewSupportRequest($event)"
+        >
+    </tm-support-request-edit-form>
+</div>

--- a/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.html
+++ b/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.html
@@ -2,6 +2,13 @@
     <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
 </ng-template>
 <div *ngIf="!isLoading; else loadingSpinner">    
+    <div *ngIf="successMsg.length > 0" class="alert alert-success" style="display: flex; flex-direction: column; ">
+        <div *ngFor="let m of successMsg">
+            <p>{{ m }}</p>
+        </div>
+        
+        <button (click)="onDismissSuccessMessage()" class="btn btn-sm"><p>dismiss</p></button>
+    </div>
     <h1 class="color-orange">Request for Support</h1>
     <p>Please fill in this form to submit a Support Request, including: Bug reports, New feature suggestions, Inquiries, etc.</p>
     <tm-support-request-edit-form

--- a/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.scss
+++ b/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.scss
@@ -1,0 +1,4 @@
+tm-ajax-loading {
+    display: flex; 
+    justify-content: center;
+}

--- a/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.spec.ts
+++ b/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StudentSupportRequestPageComponent } from './student-support-request-page.component';
+
+describe('StudentSupportRequestPageComponent', () => {
+  let component: StudentSupportRequestPageComponent;
+  let fixture: ComponentFixture<StudentSupportRequestPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StudentSupportRequestPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StudentSupportRequestPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.ts
+++ b/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.ts
@@ -6,6 +6,7 @@ import { ErrorMessageOutput } from '../../error-message-output';
 import { SupportRequestFormMode, SupportRequestFormModel } from '../../components/support-request-edit-form/support-request-edit-form-model';
 import { StatusMessageService } from 'src/web/services/status-message.service';
 import { AuthService } from 'src/web/services/auth.service';
+import { LinkService } from 'src/web/services/link.service';
 
 @Component({
   selector: 'tm-student-support-request-page',
@@ -22,12 +23,18 @@ export class StudentSupportRequestPageComponent implements OnInit {
   email = "";
   formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
 
+  successMsg: string[] = [];
+  private SUCCESSFUL_CREATE_MESSAGE: string[] = ["Successfully submitted a SupportRequest!", "Please save this link to view/make updates to your support request:"]; 
+
+
   constructor(private supportRequestService: SupportRequestService,
               private statusMessageService: StatusMessageService,
-              private authService: AuthService) { }
+              private authService: AuthService,
+              private linkService: LinkService) { }
 
   ngOnInit(): void {
     this.formMode = SupportRequestFormMode.USER_ADD;
+    this.successMsg = [];
 
     this.isLoading = true;
     this.email = "";
@@ -63,8 +70,10 @@ export class StudentSupportRequestPageComponent implements OnInit {
 
     this.isLoading = true;
     this.supportRequestService.createSupportRequest(req).subscribe({
-      next: (_sr: SupportRequest) => {
-        this.statusMessageService.showSuccessToast("Successfully submitted a Support Request");
+      next: (sr: SupportRequest) => {
+        let sr_url = this.linkService.generateEditSupportRequestUrl(sr.id);
+        this.successMsg = this.SUCCESSFUL_CREATE_MESSAGE
+        this.successMsg.push(sr_url);
       },
       error: (err: ErrorMessageOutput) => {
         this.statusMessageService.showErrorToast(err.error.message);
@@ -73,5 +82,9 @@ export class StudentSupportRequestPageComponent implements OnInit {
         this.isLoading = false;
       }
     });
+  }
+
+  onDismissSuccessMessage(): void {
+    this.successMsg = [];
   }
 }

--- a/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.ts
+++ b/src/web/app/pages-student/student-support-request-page/student-support-request-page.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnInit } from '@angular/core';
+import { SupportRequestService } from 'src/web/services/support-request.service';
+import { AuthInfo, SupportRequest } from 'src/web/types/api-output';
+import { SupportRequestCreateRequest } from 'src/web/types/api-request';
+import { ErrorMessageOutput } from '../../error-message-output';
+import { SupportRequestFormMode, SupportRequestFormModel } from '../../components/support-request-edit-form/support-request-edit-form-model';
+import { StatusMessageService } from 'src/web/services/status-message.service';
+import { AuthService } from 'src/web/services/auth.service';
+
+@Component({
+  selector: 'tm-student-support-request-page',
+  templateUrl: './student-support-request-page.component.html',
+  styleUrls: ['./student-support-request-page.component.scss']
+})
+export class StudentSupportRequestPageComponent implements OnInit {
+  // enum
+  SupportRequestFormMode: typeof SupportRequestFormMode = SupportRequestFormMode;
+
+  isLoading: boolean = false;
+  sr: SupportRequest | null = null;
+
+  email = "";
+  formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
+
+  constructor(private supportRequestService: SupportRequestService,
+              private statusMessageService: StatusMessageService,
+              private authService: AuthService) { }
+
+  ngOnInit(): void {
+    this.formMode = SupportRequestFormMode.USER_ADD;
+
+    this.isLoading = true;
+    this.email = "";
+    this.authService.getAuthUser().subscribe({
+      next: (res: AuthInfo) => {
+        if (res.user) {
+          console.log(res.user);
+          this.email = res.user?.id || "";
+        } 
+      },
+      error: () => {
+        // Fail silently
+      },
+      complete: () => {
+        this.isLoading = false;
+      }
+    });
+  }
+
+  public createNewSupportRequest(formModel: SupportRequestFormModel) {
+    let req: SupportRequestCreateRequest = {
+        id: formModel.id,
+        email: formModel.email,
+        title: formModel.title,
+        description: formModel.description,
+        createdAt: new Date().getTime(),
+        modifiedAt: new Date().getTime(),
+        status: formModel.status,
+        category: formModel.category,
+        response: formModel.response,
+        hasNewChanges: formModel.hasNewChanges   
+    };
+
+    this.isLoading = true;
+    this.supportRequestService.createSupportRequest(req).subscribe({
+      next: (_sr: SupportRequest) => {
+        this.statusMessageService.showSuccessToast("Successfully submitted a Support Request");
+      },
+      error: (err: ErrorMessageOutput) => {
+        this.statusMessageService.showErrorToast(err.error.message);
+      },
+      complete: () => {
+        this.isLoading = false;
+      }
+    });
+  }
+}

--- a/src/web/app/pages-student/student-support-request-page/student-support-request-page.module.ts
+++ b/src/web/app/pages-student/student-support-request-page/student-support-request-page.module.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
+import { AjaxPreloadModule } from '../../components/ajax-preload/ajax-preload.module';
+import { LoadingRetryModule } from '../../components/loading-retry/loading-retry.module';
+import { LoadingSpinnerModule } from '../../components/loading-spinner/loading-spinner.module';
+import { ProgressBarModule } from '../../components/progress-bar/progress-bar.module';
+import { NgModule } from '@angular/core';
+import { StudentSupportRequestPageComponent } from './student-support-request-page.component';
+import { SupportRequestEditFormModule } from '../../components/support-request-edit-form/support-request-edit-form.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: StudentSupportRequestPageComponent,
+  },
+];
+
+/**
+ * Module for Student Support Request page.
+ */
+@NgModule({
+  declarations: [
+    StudentSupportRequestPageComponent,
+  ],
+  exports: [
+    StudentSupportRequestPageComponent,
+  ],
+  imports: [
+    CommonModule,
+    AjaxPreloadModule,
+    RouterModule.forChild(routes),
+    SupportRequestEditFormModule,
+    AjaxLoadingModule,
+    LoadingRetryModule,
+    ProgressBarModule,
+    LoadingSpinnerModule,
+  ],
+})
+export class StudentSupportRequestPageModule { }

--- a/src/web/services/link.service.ts
+++ b/src/web/services/link.service.ts
@@ -19,6 +19,7 @@ export class LinkService {
   INSTRUCTOR_STUDENT_PROFILE_PAGE: string = '/instructor/courses/student/details';
   SESSIONS_SUBMISSION_PAGE: string = '/sessions/submission';
   SESSIONS_RESULT_PAGE: string = '/sessions/result';
+  EDIT_SUPPORT_REQUEST_PAGE: string = '/front/edit-support-request';
 
   constructor(private navigationService: NavigationService) {}
 
@@ -146,6 +147,21 @@ export class LinkService {
     this.filterEmptyParams(params);
     const encodedParams: string = this.navigationService.encodeParams(params);
     return `${frontendUrl}${this.URI_PREFIX}${this.SESSIONS_RESULT_PAGE}${encodedParams}`;
+  }
+
+  /**
+   * Generates a url for editting a support request.
+   */
+  generateEditSupportRequestUrl(srId: string): string {
+    const frontendUrl: string = window.location.origin;
+    const params: {
+      [key: string]: string,
+    } = {
+      supportRequestId: srId,
+    };
+    this.filterEmptyParams(params);
+    const encodedParams: string = this.navigationService.encodeParams(params);
+    return `${frontendUrl}${this.URI_PREFIX}${this.EDIT_SUPPORT_REQUEST_PAGE}${encodedParams}`;
   }
 
   /**


### PR DESCRIPTION
### Create and Add Form Views
- [x] Add the Support Request Model Component
- Create Support Request:
    - [x] for Public
    - [x] for Registered Students
    - [x] for Registered Instructors
    (Note: the code for all 3 files is very similar, only difference is that for registered, in OnInit() call, will get Auth Info to get the user's email, ie. user.id)

- [x] Edit Support Request for Users
- [x] Edit Support Request for Admins

---

#### Create Support Request page (for registered Instructors) (USER_ADD)
![Screenshot 2023-02-03 at 12 35 16 PM](https://user-images.githubusercontent.com/77243938/216513798-c879b7aa-c7de-4681-89b3-33fdd892f91d.png)
![Screenshot 2023-02-03 at 1 03 09 PM](https://user-images.githubusercontent.com/77243938/216517187-9384588c-ef81-408d-b140-3de72e63f359.png)
- email is auto-filled
- identical to Create Support Request page for public use (unregistered) and registered students
- upon successful creation of Support Request, display pop up banner with the support request url

#### Edit Support Request Page for Admins (ADMIN_EDIT)
![Screenshot 2023-02-03 at 1 03 40 PM](https://user-images.githubusercontent.com/77243938/216517160-b737fd32-62cc-4b24-bc7f-682f96532a75.png)
- only response and status is editable
- status options allowed: submitted, pending and closed

#### Edit Support Request Page for Users (USER_EDIT)
![Screenshot 2023-02-03 at 1 02 14 PM](https://user-images.githubusercontent.com/77243938/216517087-d576af44-6dbd-4266-9bc9-a11c9ee0e7d0.png)
- only email, title, category and description are editable
- status options allowed: submitted, request to close
