### PR TITLE
Integrate API into support requests forms

### DIFF
--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
@@ -120,11 +120,13 @@ export class SupportRequestEditFormComponent implements OnInit {
     let now = new Date().getTime();
     this.formModel.createdAt = now;
     this.formModel.modifiedAt = now;
+    this.formModel.hasNewChanges = true;
     this.onCreateSupportRequestEvent.emit(this.formModel);
   }
 
   public onUpdate(): void {
     this.formModel.modifiedAt = new Date().getTime();
+    this.formModel.hasNewChanges = true;
     this.onUpdateSupportRequestEvent.emit(this.formModel);
   }
 }

--- a/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
+++ b/src/web/app/components/support-request-edit-form/support-request-edit-form.component.ts
@@ -1,119 +1,130 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { StatusMessageService } from "src/web/services/status-message.service";
-import { SupportRequestCategory, SupportRequestStatus } from "src/web/types/api-output";
+import { SupportRequestService } from "src/web/services/support-request.service";
+import {
+  SupportRequest,
+  SupportRequestCategory,
+  SupportRequestStatus,
+} from "src/web/types/api-output";
 import { ErrorMessageOutput } from "../../error-message-output";
-import { SupportRequestFormModel, SupportRequestFormMode } from "./support-request-edit-form-model";
+import {
+  SupportRequestFormModel,
+  SupportRequestFormMode,
+} from "./support-request-edit-form-model";
 
 /**
  * The support request edit form component.
  */
 @Component({
-selector: 'tm-support-request-edit-form',
-templateUrl: './support-request-edit-form.component.html',
-styleUrls: ['./support-request-edit-form.component.scss'],
+  selector: "tm-support-request-edit-form",
+  templateUrl: "./support-request-edit-form.component.html",
+  styleUrls: ["./support-request-edit-form.component.scss"],
 })
 export class SupportRequestEditFormComponent implements OnInit {
-    // enum
-    SupportRequestFormMode: typeof SupportRequestFormMode = SupportRequestFormMode;
+  // enum
+  SupportRequestFormMode: typeof SupportRequestFormMode =
+    SupportRequestFormMode;
 
-    @Input()
-    supportRequestId: string = "";
+  @Input()
+  supportRequestId: string = "";
 
-    @Input()
-    email: string = "";
+  @Input()
+  email: string = "";
 
-    @Input()
-    formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
+  @Input()
+  formMode: SupportRequestFormMode = SupportRequestFormMode.USER_ADD;
 
-    formModel: SupportRequestFormModel = {
-        id: "",
-        email: "",
-        title: "",
-        description: "",
-        status: SupportRequestStatus.SUBMITTED,
-        category: SupportRequestCategory.OTHERS,
-        response: "",
-        hasNewChanges: true,
-        createdAt: 1,
-        modifiedAt: 1,
+  formModel: SupportRequestFormModel = {
+    id: "",
+    email: "",
+    title: "",
+    description: "",
+    status: SupportRequestStatus.SUBMITTED,
+    category: SupportRequestCategory.OTHERS,
+    response: "",
+    hasNewChanges: true,
+    createdAt: 1,
+    modifiedAt: 1,
+  };
+
+  @Output()
+  onCreateSupportRequestEvent: EventEmitter<SupportRequestFormModel> =
+    new EventEmitter();
+
+  @Output()
+  onUpdateSupportRequestEvent: EventEmitter<SupportRequestFormModel> =
+    new EventEmitter();
+
+  public categories: String[] = Object.values(SupportRequestCategory);
+  public statuses: String[] = Object.values(SupportRequestStatus);
+
+  constructor(
+    private route: ActivatedRoute,
+    private statusMessageService: StatusMessageService,
+    private supportRequestService: SupportRequestService
+  ) {}
+
+  ngOnInit(): void {
+    this.formModel.email = this.email;
+    let srId = "";
+
+    if (this.formMode === SupportRequestFormMode.ADMIN_EDIT) {
+      srId = this.supportRequestId;
+    } else if (this.formMode === SupportRequestFormMode.USER_EDIT) {
+      this.route.queryParams.subscribe({
+        next: (queryParams: any) => {
+          if (queryParams != null) {
+            srId = queryParams.supportRequestId;
+          }
+        },
+        error: (err: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(err.error.message);
+        },
+      });
     }
 
-    @Output()
-    onCreateSupportRequestEvent: EventEmitter<SupportRequestFormModel> = new EventEmitter();
-
-    @Output()
-    onUpdateSupportRequestEvent: EventEmitter<SupportRequestFormModel> = new EventEmitter();
-    
-
-    public categories: String[] = Object.values(SupportRequestCategory);
-    public statuses: String[] = Object.values(SupportRequestStatus);
-
-    constructor (private route: ActivatedRoute,
-                private statusMessageService: StatusMessageService) {
+    if (srId !== "") {
+      this.supportRequestService
+        .getSupportRequest(this.supportRequestId)
+        .subscribe({
+          next: (sr: SupportRequest) => {
+            this.formModel = {
+              id: sr.id,
+              email: sr.email,
+              title: sr.title,
+              description: sr.description,
+              status: sr.status,
+              category: sr.category,
+              response: sr.response,
+              hasNewChanges: sr.hasNewChanges,
+              createdAt: sr.createdAt,
+              modifiedAt: sr.modifiedAt,
+            };
+          },
+          error: (err: ErrorMessageOutput) => {
+            this.statusMessageService.showErrorToast(err.error.message);
+          },
+        });
     }
+  }
 
-    ngOnInit(): void {
-        this.formModel.email = this.email;
-        let srId = "";
+  public enumToOption(str: String) {
+    return str
+      .split("_")
+      .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+      .join(" ");
+  }
 
-        if (this.formMode === SupportRequestFormMode.ADMIN_EDIT) {
-            srId = this.supportRequestId;
-            
-        } else if (this.formMode === SupportRequestFormMode.USER_EDIT) {
-            this.route.queryParams.subscribe({
-                next: (queryParams: any) => {
-                    if (queryParams != null) {
-                        srId = queryParams.supportRequestId;
-                    }
-                },
-                error: (err: ErrorMessageOutput) => {
-                    this.statusMessageService.showErrorToast(err.error.message);
-                }
-            })
-        }
+  public onCreate(): void {
+    let now = new Date().getTime();
+    this.formModel.createdAt = now;
+    this.formModel.modifiedAt = now;
+    this.onCreateSupportRequestEvent.emit(this.formModel);
+  }
 
-        if (srId !== "") {
-            // this.supportRequestService.getSupportRequestById(this.supportRequestId).subscribe({
-            //      next: (sr SupportRequest) => {
-            //             this.model.id = sr.id 
-            //             // continue with other fields
-            //      },
-            //      error: (err: ErrorMessageOutput) => {
-            //          this.isLoading = false;
-            //          // showErrorToast
-            //          // set formModel to default fields 
-            //      }
-            // })
-            
-            this.formModel = { // Mock data – TO REPLACE
-                id: "123 123 Mock data",
-                email: "abc@gmail.com",
-                title: "Mock data title for Support Request",
-                description: "<description>",
-                status: SupportRequestStatus.PENDING,
-                category: SupportRequestCategory.BUG_REPORT,
-                response: "Please provide more information!",
-                hasNewChanges: false,
-                createdAt: 1,
-                modifiedAt: new Date().getTime(),
-            }
-        }
-    }
-
-    public enumToOption(str: String) {
-        return str.split("_").map(word => word.charAt(0) + word.slice(1).toLowerCase()).join(" ");
-    }
-
-    public onCreate(): void {
-        let now = new Date().getTime();
-        this.formModel.createdAt = now;
-        this.formModel.modifiedAt = now;
-        this.onCreateSupportRequestEvent.emit(this.formModel);
-    }
-
-    public onUpdate(): void {
-        this.formModel.modifiedAt = new Date().getTime();
-        this.onUpdateSupportRequestEvent.emit(this.formModel);
-    }
+  public onUpdate(): void {
+    this.formModel.modifiedAt = new Date().getTime();
+    this.onUpdateSupportRequestEvent.emit(this.formModel);
+  }
 }

--- a/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.ts
+++ b/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.ts
@@ -26,6 +26,10 @@ export class AdminEditSupportRequestPageComponent implements OnInit {
   isLoading: boolean = false;
 
   ngOnInit() {
+    this.onLoad();
+  }
+
+  private onLoad(): void {
     this.isLoading = true;
     this.route.queryParams.subscribe({
       next: (queryParams: any) => {
@@ -68,12 +72,14 @@ export class AdminEditSupportRequestPageComponent implements OnInit {
           this.statusMessageService.showSuccessToast(
             "Support request updated successfully."
           );
-          this.ngOnInit();
+          this.onLoad();
         },
         error: (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);
         },
+        complete: () => {
+          this.isLoading = false;
+        }
       });
-    this.isLoading = false;
   }
 }

--- a/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.ts
+++ b/src/web/app/pages-admin/admin-edit-support-request-page/admin-edit-support-request-page.component.ts
@@ -1,47 +1,79 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { StatusMessageService } from "src/web/services/status-message.service";
-import { SupportRequestFormMode, SupportRequestFormModel } from "../../components/support-request-edit-form/support-request-edit-form-model";
-// import { SupportRequestService } from "src/web/services/support-request.service"; 
+import { SupportRequestService } from "src/web/services/support-request.service";
+import {
+  SupportRequestFormMode,
+  SupportRequestFormModel,
+} from "../../components/support-request-edit-form/support-request-edit-form-model";
+// import { SupportRequestService } from "src/web/services/support-request.service";
 import { ErrorMessageOutput } from "../../error-message-output";
 
 @Component({
-    selector: 'tm-admin-edit-support-request-page',
-    templateUrl: './admin-edit-support-request-page.component.html',
-    styleUrls: ['./admin-edit-support-request-page.component.scss']
+  selector: "tm-admin-edit-support-request-page",
+  templateUrl: "./admin-edit-support-request-page.component.html",
+  styleUrls: ["./admin-edit-support-request-page.component.scss"],
 })
 export class AdminEditSupportRequestPageComponent implements OnInit {
-    
-    constructor(private route: ActivatedRoute,
-                private statusMessageService: StatusMessageService) {
-    }
+  constructor(
+    private route: ActivatedRoute,
+    private statusMessageService: StatusMessageService,
+    private supportRequestService: SupportRequestService
+  ) {}
 
-    supportRequestId: String = "";
-    formMode: SupportRequestFormMode = SupportRequestFormMode.ADMIN_EDIT;
-    isLoading: boolean = false;
+  supportRequestId: String = "";
+  formMode: SupportRequestFormMode = SupportRequestFormMode.ADMIN_EDIT;
+  isLoading: boolean = false;
 
-    ngOnInit() {
-        this.isLoading = true;
-        this.route.queryParams.subscribe({
-            next: (queryParams: any) => {
-                this.isLoading = false;
-                if (queryParams != null) {
-                    this.supportRequestId = queryParams.supportRequestId || "";
-                } else {
-                    this.supportRequestId = "";
-                }
-            },
-            error: (err: ErrorMessageOutput) => {
-                this.isLoading = false;
-                this.supportRequestId = "";
-                this.statusMessageService.showErrorToast(err.error.message);
-            }
-        })
-    }
-
-    public updateSupportRequest(_formModel: SupportRequestFormModel) {
-        this.isLoading = true;
-        console.log("Updating DB...");
+  ngOnInit() {
+    this.isLoading = true;
+    this.route.queryParams.subscribe({
+      next: (queryParams: any) => {
         this.isLoading = false;
-    }
+        if (queryParams != null) {
+          this.supportRequestId = queryParams.supportRequestId || "";
+        } else {
+          this.supportRequestId = "";
+        }
+      },
+      error: (err: ErrorMessageOutput) => {
+        this.isLoading = false;
+        this.supportRequestId = "";
+        this.statusMessageService.showErrorToast(err.error.message);
+      },
+    });
+  }
+
+  public updateSupportRequest(formModel: SupportRequestFormModel) {
+    this.isLoading = true;
+
+    this.supportRequestService
+      .updateSupportRequest(
+        {
+          id: formModel.id,
+          email: formModel.email,
+          title: formModel.title,
+          description: formModel.description,
+          status: formModel.status,
+          category: formModel.category,
+          response: formModel.response,
+          hasNewChanges: formModel.hasNewChanges,
+          createdAt: formModel.createdAt,
+          modifiedAt: formModel.modifiedAt,
+        },
+        formModel.id
+      )
+      .subscribe({
+        next: () => {
+          this.statusMessageService.showSuccessToast(
+            "Support request updated successfully."
+          );
+          this.ngOnInit();
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
+    this.isLoading = false;
+  }
 }

--- a/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.ts
+++ b/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.ts
@@ -25,6 +25,10 @@ export class EditSupportRequestPageComponent implements OnInit {
   isLoading: boolean = false;
 
   ngOnInit() {
+    this.onLoad();
+  }
+
+  private onLoad(): void {
     this.isLoading = true;
     this.route.queryParams.subscribe({
       next: (queryParams: any) => {
@@ -67,13 +71,14 @@ export class EditSupportRequestPageComponent implements OnInit {
           this.statusMessageService.showSuccessToast(
             "Support request updated successfully."
           );
-          this.ngOnInit();
+          this.onLoad();
         },
         error: (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorToast(resp.error.message);
         },
+        complete: () => {
+          this.isLoading = false;
+        }
       });
-
-    this.isLoading = false;
   }
 }

--- a/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.ts
+++ b/src/web/app/pages-static/edit-support-request-page/edit-support-request-page.component.ts
@@ -1,47 +1,79 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { StatusMessageService } from "src/web/services/status-message.service";
-import { SupportRequestFormMode, SupportRequestFormModel } from "../../components/support-request-edit-form/support-request-edit-form-model";
-// import { SupportRequestService } from "src/web/services/support-request.service"; 
+import { SupportRequestService } from "src/web/services/support-request.service";
+import {
+  SupportRequestFormMode,
+  SupportRequestFormModel,
+} from "../../components/support-request-edit-form/support-request-edit-form-model";
 import { ErrorMessageOutput } from "../../error-message-output";
 
 @Component({
-    selector: 'tm-edit-support-request-page',
-    templateUrl: './edit-support-request-page.component.html',
-    styleUrls: ['./edit-support-request-page.component.scss']
+  selector: "tm-edit-support-request-page",
+  templateUrl: "./edit-support-request-page.component.html",
+  styleUrls: ["./edit-support-request-page.component.scss"],
 })
 export class EditSupportRequestPageComponent implements OnInit {
-    
-    constructor(private route: ActivatedRoute,
-                private statusMessageService: StatusMessageService) {
-    }
+  constructor(
+    private route: ActivatedRoute,
+    private statusMessageService: StatusMessageService,
+    private supportRequestService: SupportRequestService
+  ) {}
 
-    supportRequestId: String = "";
-    formMode: SupportRequestFormMode = SupportRequestFormMode.USER_EDIT;
-    isLoading: boolean = false;
+  supportRequestId: String = "";
+  formMode: SupportRequestFormMode = SupportRequestFormMode.USER_EDIT;
+  isLoading: boolean = false;
 
-    ngOnInit() {
-        this.isLoading = true;
-        this.route.queryParams.subscribe({
-            next: (queryParams: any) => {
-                this.isLoading = false;
-                if (queryParams != null) {
-                    this.supportRequestId = queryParams.supportRequestId || "";
-                } else {
-                    this.supportRequestId = "";
-                }
-            },
-            error: (err: ErrorMessageOutput) => {
-                this.isLoading = false;
-                this.supportRequestId = "";
-                this.statusMessageService.showErrorToast(err.error.message);
-            }
-        })
-    }
-
-    public updateSupportRequest(_formModel: SupportRequestFormModel) {
-        this.isLoading = true;
-        console.log("Updating DB...");
+  ngOnInit() {
+    this.isLoading = true;
+    this.route.queryParams.subscribe({
+      next: (queryParams: any) => {
         this.isLoading = false;
-    }
+        if (queryParams != null) {
+          this.supportRequestId = queryParams.supportRequestId || "";
+        } else {
+          this.supportRequestId = "";
+        }
+      },
+      error: (err: ErrorMessageOutput) => {
+        this.isLoading = false;
+        this.supportRequestId = "";
+        this.statusMessageService.showErrorToast(err.error.message);
+      },
+    });
+  }
+
+  public updateSupportRequest(formModel: SupportRequestFormModel) {
+    this.isLoading = true;
+
+    this.supportRequestService
+      .updateSupportRequest(
+        {
+          id: formModel.id,
+          email: formModel.email,
+          title: formModel.title,
+          description: formModel.description,
+          status: formModel.status,
+          category: formModel.category,
+          response: formModel.response,
+          hasNewChanges: formModel.hasNewChanges,
+          createdAt: formModel.createdAt,
+          modifiedAt: formModel.modifiedAt,
+        },
+        formModel.id
+      )
+      .subscribe({
+        next: () => {
+          this.statusMessageService.showSuccessToast(
+            "Support request updated successfully."
+          );
+          this.ngOnInit();
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
+
+    this.isLoading = false;
+  }
 }

--- a/src/web/services/support-request.service.ts
+++ b/src/web/services/support-request.service.ts
@@ -1,45 +1,82 @@
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { ResourceEndpoints } from '../types/api-const';
-import {
-  SupportRequest, SupportRequests
-} from '../types/api-output';
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { ResourceEndpoints } from "../types/api-const";
+import { SupportRequest, SupportRequests } from "../types/api-output";
 import {
   SupportRequestCreateRequest,
-} from '../types/api-request';
-import { HttpRequestService } from './http-request.service';
+  SupportRequestUpdateRequest,
+} from "../types/api-request";
+import { HttpRequestService } from "./http-request.service";
 
 /**
  * Handles support request related logic injection
  */
 @Injectable({
-providedIn: 'root',
+  providedIn: "root",
 })
 export class SupportRequestService {
+  constructor(private httpRequestService: HttpRequestService) {}
 
-    constructor(private httpRequestService: HttpRequestService) { }
+  /**
+   * Creates a support request by calling API.
+   */
+  createSupportRequest(
+    request: SupportRequestCreateRequest
+  ): Observable<SupportRequest> {
+    return this.httpRequestService.post(
+      ResourceEndpoints.SUPPORT_REQUEST,
+      {},
+      request
+    );
+  }
 
-    /**
-     * Creates a support request by calling API.
-     */
-    createSupportRequest(request: SupportRequestCreateRequest): Observable<SupportRequest> {
-        return this.httpRequestService.post(ResourceEndpoints.SUPPORT_REQUEST, {}, request);
-    }
+  /**
+   * Retrieves all support requests by calling API.
+   */
+  getSupportRequests(): Observable<SupportRequests> {
+    return this.httpRequestService.get(ResourceEndpoints.SUPPORT_REQUESTS);
+  }
 
-    /**
-     * Retrieves all support requests by calling API.
-     */
-    getSupportRequests(): Observable<SupportRequests> {
-      return this.httpRequestService.get(ResourceEndpoints.SUPPORT_REQUESTS);
-    }
+  /**
+   * Retrieves all support requests for an email
+   */
+  getSupportRequestsForEmail(email: string): Observable<SupportRequests> {
+    const paramsMap: Record<string, string> = {
+      email: email,
+    };
+    return this.httpRequestService.get(
+      ResourceEndpoints.SUPPORT_REQUESTS,
+      paramsMap
+    );
+  }
 
-    /**
-     * Retrieves all support requests for an email
-     */
-    getSupportRequestsForEmail(email: string): Observable<SupportRequests> {
-      const paramsMap: Record<string, string> = {
-        email: email,
-      };
-      return this.httpRequestService.get(ResourceEndpoints.SUPPORT_REQUESTS, paramsMap);
-    }
+  /**
+   * Retrieve a support request by id by calling API.
+   */
+  getSupportRequest(supportRequestId: string): Observable<SupportRequest> {
+    const paramMap: Record<string, string> = {
+      supportrequestid: supportRequestId,
+    };
+    return this.httpRequestService.get(
+      ResourceEndpoints.SUPPORT_REQUEST,
+      paramMap
+    );
+  }
+
+  /**
+   * Updates a support request by calling API.
+   */
+  updateSupportRequest(
+    request: SupportRequestUpdateRequest,
+    supportRequestId: string
+  ): Observable<SupportRequest> {
+    const paramMap: Record<string, string> = {
+      supportrequestid: supportRequestId,
+    };
+    return this.httpRequestService.put(
+      ResourceEndpoints.SUPPORT_REQUEST,
+      paramMap,
+      request
+    );
+  }
 }


### PR DESCRIPTION
## Changes
- Populate edit support request form via `getSupportRequest` API
- Integrate edit form to edit support request API